### PR TITLE
Fix bump version action fails if no tag is present

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -22,10 +22,6 @@ jobs:
       PAT: ${{ secrets.ORG_PAT }}
 
     steps:
-      - name: Printing env
-        run: |
-          echo ${PAT}
-
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -50,7 +46,7 @@ jobs:
             echo "type=patch" >> $GITHUB_OUTPUT
           else
             echo "No bump label found" >&2
-            exit 1
+            exit 0
           fi
 
       - name: Calculate next version

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -51,6 +51,7 @@ jobs:
 
       - name: Calculate next version
         id: version
+        if: steps.bump.outputs.type != ''
         run: |
           v=${{ steps.latest.outputs.tag }}
           v=${v#v}
@@ -65,6 +66,7 @@ jobs:
           echo "next=v$major.$minor.$patch" >> $GITHUB_OUTPUT
 
       - name: Create and push tag
+        if: steps.bump.outputs.type != ''
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"


### PR DESCRIPTION
## Summary

Fixes #3

* update `bump-version.yml` to exit with status code `0` instead of `1` if no tag is present
* remove testing `echo` of `PAT` in `bump-version.yml`
* subsequent actions only continue if bump type is not set
