### PR TITLE
Update publish pypi library to use uv

### DIFF
--- a/.github/workflows/publish-pypi-library.yml
+++ b/.github/workflows/publish-pypi-library.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.13"
 
@@ -38,13 +38,10 @@ jobs:
           git config --global user.email "actions@github.com"
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+        run: uv sync
 
       - name: Run unit tests
-        run: |
-          python -m pytest -s -vv
+        run: uv run pytest -s -vv
 
       - name: Build binary
         env:
@@ -52,10 +49,9 @@ jobs:
           REF_NAME: ${{ inputs.ref_name }}
         run: |
           echo "__version__ = \"${REF_NAME}\"" > ${LIBRARY_PATH}/version.py
-          python -m build
+          uv build
 
       - name: Publish
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          python -m twine upload --username "__token__" --password ${PYPI_TOKEN} --skip-existing --verbose dist/*
+        run: uv run twine upload --username "__token__" --password ${PYPI_TOKEN} --skip-existing --verbose dist/*


### PR DESCRIPTION
## Summary

* Update action to use `uv`, as most of our projects have migrated to `uv` already